### PR TITLE
Add waitress serving and bump to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bepi-prediction-dashboard"
-version = "0.1.0"
+version = "1.0.0"
 description = "A dashboard to predict magnetospheric region for the BepiColombo mission based on MESSENGER ephemeris data"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -12,6 +12,7 @@ dependencies = [
     "pandas>=2.3.3",
     "planetary-coverage>=1.2.0",
     "plotly>=6.3.0",
+    "waitress>=3.0.2",
     "xarray>=2025.9.1",
 ]
 

--- a/src/backend.py
+++ b/src/backend.py
@@ -251,22 +251,6 @@ def bepi_probabilities(
                 / "region_maps_philpott.nc"
             )
 
-        case "90 < TAA < 270":
-            selected_probability_map = xr.load_dataset(
-                pathlib.Path(os.path.dirname(__file__))
-                / "create_probability_maps"
-                / "output"
-                / "region_maps_from_direct_input_taa_90_270.nc"
-            )
-
-        case "270 < TAA < 90":
-            selected_probability_map = xr.load_dataset(
-                pathlib.Path(os.path.dirname(__file__))
-                / "create_probability_maps"
-                / "output"
-                / "region_maps_from_direct_input_taa_n90_90.nc"
-            )
-
         case _:
             raise ValueError("Invalid dropdown selection")
 
@@ -512,22 +496,6 @@ def load_probability_maps(dropdown_value, grid_density):
                 / "create_probability_maps"
                 / "output"
                 / "region_maps_philpott.nc"
-            )
-
-        case "90 < TAA < 270":
-            selected_probability_map = xr.load_dataset(
-                pathlib.Path(os.path.dirname(__file__))
-                / "create_probability_maps"
-                / "output"
-                / "region_maps_from_direct_input_taa_90_270.nc"
-            )
-
-        case "270 < TAA < 90":
-            selected_probability_map = xr.load_dataset(
-                pathlib.Path(os.path.dirname(__file__))
-                / "create_probability_maps"
-                / "output"
-                / "region_maps_from_direct_input_taa_n90_90.nc"
             )
 
         case _:

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -1,6 +1,14 @@
+import sys
+
 import dash
+import waitress
 
 import backend
+
+if len(sys.argv) == 2:
+    num_threads = int(sys.argv[1])
+else:
+    num_threads = 4  # waitress.serve default
 
 app = dash.Dash("BepiColombo Region Prediction")
 
@@ -8,7 +16,7 @@ probability_maps_layout = dash.html.Div(
     [
         dash.html.P("Choose a crossing list to construct region probability maps"),
         dash.dcc.Dropdown(
-            ["Hollman+ 2025", "Philpott+ 2020", "270 < TAA < 90", "90 < TAA < 270"],
+            ["Hollman+ 2025", "Philpott+ 2020"],
             "Hollman+ 2025",
             id="crossing_list_choice",
             clearable=False,
@@ -168,4 +176,4 @@ def download_time_series(n_clicks, spacecraft, start_time, end_time):
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port="8050", debug=True)
+    waitress.serve(app.server, host="0.0.0.0", port=8050, threads=num_threads)

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.13"
 
 [[package]]
 name = "bepi-prediction-dashboard"
-version = "0.1.0"
+version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "dash" },
@@ -14,6 +14,7 @@ dependencies = [
     { name = "pandas" },
     { name = "planetary-coverage" },
     { name = "plotly" },
+    { name = "waitress" },
     { name = "xarray" },
 ]
 
@@ -26,6 +27,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "planetary-coverage", specifier = ">=1.2.0" },
     { name = "plotly", specifier = ">=6.3.0" },
+    { name = "waitress", specifier = ">=3.0.2" },
     { name = "xarray", specifier = ">=2025.9.1" },
 ]
 
@@ -857,6 +859,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "waitress"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/cb/04ddb054f45faa306a230769e868c28b8065ea196891f09004ebace5b184/waitress-3.0.2.tar.gz", hash = "sha256:682aaaf2af0c44ada4abfb70ded36393f0e307f4ab9456a215ce0020baefc31f", size = 179901, upload-time = "2024-11-16T20:02:35.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/57/a27182528c90ef38d82b636a11f606b0cbb0e17588ed205435f8affe3368/waitress-3.0.2-py3-none-any.whl", hash = "sha256:c56d67fd6e87c2ee598b76abdd4e96cfad1f24cacdea5078d382b1f9d7b5ed2e", size = 56232, upload-time = "2024-11-16T20:02:33.858Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
waitress.serve() offers a multi-threaded solution for hosting a dash app.

TAA filtered probability maps were removed as they are out of scope for this initial release.

Version number has been bumped to the first major release, as I believe this version of the code is suitable for deployment on the server.